### PR TITLE
refactor: write 기능을 diary 패키지에서 분리

### DIFF
--- a/app/src/main/java/com/example/myapplication/picday/presentation/diary/DiaryRoot.kt
+++ b/app/src/main/java/com/example/myapplication/picday/presentation/diary/DiaryRoot.kt
@@ -5,9 +5,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.example.myapplication.picday.presentation.diary.write.WriteScreen
-import com.example.myapplication.picday.presentation.diary.write.WriteUiMode
-import com.example.myapplication.picday.presentation.diary.write.WriteViewModel
+import com.example.myapplication.picday.presentation.write.WriteScreen
+import com.example.myapplication.picday.presentation.write.WriteUiMode
+import com.example.myapplication.picday.presentation.write.WriteViewModel
 import com.example.myapplication.picday.presentation.navigation.WriteMode
 import java.time.LocalDate
 

--- a/app/src/main/java/com/example/myapplication/picday/presentation/diary/write/WritePhotoState.kt
+++ b/app/src/main/java/com/example/myapplication/picday/presentation/diary/write/WritePhotoState.kt
@@ -1,7 +1,0 @@
-package com.example.myapplication.picday.presentation.diary.write
-
-enum class WritePhotoState {
-    KEEP,
-    NEW,
-    DELETE
-}

--- a/app/src/main/java/com/example/myapplication/picday/presentation/diary/write/WriteUIMode.kt
+++ b/app/src/main/java/com/example/myapplication/picday/presentation/diary/write/WriteUIMode.kt
@@ -1,7 +1,0 @@
-package com.example.myapplication.picday.presentation.diary.write
-
-enum class WriteUiMode {
-    VIEW,
-    ADD,
-    EDIT
-}

--- a/app/src/main/java/com/example/myapplication/picday/presentation/write/WriteEditContent.kt
+++ b/app/src/main/java/com/example/myapplication/picday/presentation/write/WriteEditContent.kt
@@ -1,4 +1,4 @@
-package com.example.myapplication.picday.presentation.diary.write
+package com.example.myapplication.picday.presentation.write
 
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer

--- a/app/src/main/java/com/example/myapplication/picday/presentation/write/WritePhotoItem.kt
+++ b/app/src/main/java/com/example/myapplication/picday/presentation/write/WritePhotoItem.kt
@@ -1,4 +1,4 @@
-package com.example.myapplication.picday.presentation.diary.write
+package com.example.myapplication.picday.presentation.write
 
 data class WritePhotoItem(
     val id: String,

--- a/app/src/main/java/com/example/myapplication/picday/presentation/write/WritePhotoState.kt
+++ b/app/src/main/java/com/example/myapplication/picday/presentation/write/WritePhotoState.kt
@@ -1,0 +1,7 @@
+package com.example.myapplication.picday.presentation.write
+
+enum class WritePhotoState {
+    KEEP,
+    NEW,
+    DELETE
+}

--- a/app/src/main/java/com/example/myapplication/picday/presentation/write/WriteScreen.kt
+++ b/app/src/main/java/com/example/myapplication/picday/presentation/write/WriteScreen.kt
@@ -1,4 +1,4 @@
-package com.example.myapplication.picday.presentation.diary.write
+package com.example.myapplication.picday.presentation.write
 
 import android.graphics.BitmapFactory
 import androidx.activity.result.PickVisualMediaRequest

--- a/app/src/main/java/com/example/myapplication/picday/presentation/write/WriteState.kt
+++ b/app/src/main/java/com/example/myapplication/picday/presentation/write/WriteState.kt
@@ -1,4 +1,4 @@
-package com.example.myapplication.picday.presentation.diary.write
+package com.example.myapplication.picday.presentation.write
 
 data class WriteState(
     val uiMode: WriteUiMode = WriteUiMode.VIEW,

--- a/app/src/main/java/com/example/myapplication/picday/presentation/write/WriteUIMode.kt
+++ b/app/src/main/java/com/example/myapplication/picday/presentation/write/WriteUIMode.kt
@@ -1,0 +1,7 @@
+package com.example.myapplication.picday.presentation.write
+
+enum class WriteUiMode {
+    VIEW,
+    ADD,
+    EDIT
+}

--- a/app/src/main/java/com/example/myapplication/picday/presentation/write/WriteViewContent.kt
+++ b/app/src/main/java/com/example/myapplication/picday/presentation/write/WriteViewContent.kt
@@ -1,4 +1,4 @@
-package com.example.myapplication.picday.presentation.diary.write
+package com.example.myapplication.picday.presentation.write
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.ColumnScope

--- a/app/src/main/java/com/example/myapplication/picday/presentation/write/WriteViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/picday/presentation/write/WriteViewModel.kt
@@ -1,4 +1,4 @@
-package com.example.myapplication.picday.presentation.diary.write
+package com.example.myapplication.picday.presentation.write
 
 import androidx.lifecycle.ViewModel
 import com.example.myapplication.picday.domain.repository.DiaryRepository


### PR DESCRIPTION
변경 내용:
- presentation/diary/write에 있던 작성 관련 파일들을
  presentation/write 패키지로 이동함
- 패키지 선언 및 import를 새 경로에 맞게 정리함
- 로직 및 동작 변경은 없음

Issue 1에서 수행한 주요 리팩토링:
- DiaryViewModel을 날짜/목록 전용으로 슬림화
- WriteViewModel 분리로 작성/편집 로직 이전
- DiaryRoot 도입으로 화면 조립과 상태 전달 책임 분리
- 편집 모드에서 기존 텍스트/사진 로딩 및
  사진 유지/삭제 흐름 안정화

변경 이유:
- Issue 1에서 정리한 구조를 기준으로
  write 기능을 독립적인 UI feature로 명확히 분리하기 위함
- Root Composable 기반 화면 구조와의 일관성 확보

영향 범위:
- WriteViewModel, WriteScreen, WriteState 등 작성 관련 UI
- DiaryRoot import 경로 수정

검증:
- gradlew clean assembleDebug --no-build-cache 빌드 성공
- docs/qa/manual-checklist-v1.md 기준 핵심 흐름 확인
- 기능 로직 변경 없음

Closes #1
