### PR TITLE
feat: 다이어리 상세 화면에 사진 페이저 기능 추가(#10)

### DIFF
--- a/app/src/main/java/com/example/myapplication/picday/presentation/diary/DiaryRoot.kt
+++ b/app/src/main/java/com/example/myapplication/picday/presentation/diary/DiaryRoot.kt
@@ -32,9 +32,14 @@ fun DiaryRoot(
     val writeViewModel: WriteViewModel = hiltViewModel()
     val diaryState by diaryViewModel.uiState.collectAsState()
     val writeState by writeViewModel.uiState.collectAsState()
+    val lastDiaryItem = diaryState.uiItems.lastOrNull()
     val coverPhotoUri = when (writeState.uiMode) {
-        WriteUiMode.VIEW -> diaryState.uiItems.lastOrNull()?.coverPhotoUri
+        WriteUiMode.VIEW -> lastDiaryItem?.coverPhotoUri
         else -> writeViewModel.getCoverPhotoUri()
+    }
+    val viewModePhotoUris = when (writeState.uiMode) {
+        WriteUiMode.VIEW -> lastDiaryItem?.photoUris ?: emptyList()
+        else -> emptyList()
     }
 
     LaunchedEffect(selectedDate) {
@@ -69,6 +74,7 @@ fun DiaryRoot(
                 items = diaryState.uiItems,
                 writeState = writeState,
                 coverPhotoUri = coverPhotoUri,
+                viewModePhotoUris = viewModePhotoUris,
                 onBack = onBack,
                 onSave = {
                     writeViewModel.onSave(selectedDate)

--- a/app/src/main/java/com/example/myapplication/picday/presentation/diary/DiaryUiItem.kt
+++ b/app/src/main/java/com/example/myapplication/picday/presentation/diary/DiaryUiItem.kt
@@ -7,5 +7,6 @@ data class DiaryUiItem(
     val date: LocalDate,
     val title: String?,
     val previewContent: String,
-    val coverPhotoUri: String?
+    val coverPhotoUri: String?,
+    val photoUris: List<String> = emptyList()
 )

--- a/app/src/main/java/com/example/myapplication/picday/presentation/diary/DiaryViewModel.kt
+++ b/app/src/main/java/com/example/myapplication/picday/presentation/diary/DiaryViewModel.kt
@@ -82,6 +82,7 @@ class DiaryViewModel @Inject constructor(
             val lastIndex = items.lastIndex
             val uiItems = items.mapIndexed { index, diary ->
                 val photos = repository.getPhotos(diary.id)
+                val photoUris = photos.map { it.uri }
                 val coverPhotoUri = deriveCoverPhotoUri(photos)
                 if (index == lastIndex) {
                     coverForDate = coverPhotoUri
@@ -91,7 +92,8 @@ class DiaryViewModel @Inject constructor(
                     date = diary.date,
                     title = diary.title,
                     previewContent = diary.previewContent,
-                    coverPhotoUri = coverPhotoUri
+                    coverPhotoUri = coverPhotoUri,
+                    photoUris = photoUris
                 )
             }
             _uiState.update {

--- a/app/src/main/java/com/example/myapplication/picday/presentation/write/WriteScreen.kt
+++ b/app/src/main/java/com/example/myapplication/picday/presentation/write/WriteScreen.kt
@@ -30,6 +30,7 @@ fun WriteScreen(
     items: List<DiaryUiItem>,
     writeState: WriteState,
     coverPhotoUri: String?,
+    viewModePhotoUris: List<String> = emptyList(),
     onBack: () -> Unit,
     onSave: () -> Unit,
     onAddClick: () -> Unit,
@@ -101,6 +102,7 @@ fun WriteScreen(
             WriteContent(
                 uiMode = writeState.uiMode,
                 coverPhotoUri = coverPhotoUri,
+                viewModePhotoUris = viewModePhotoUris,
                 items = items,
                 title = writeState.title,
                 content = writeState.content,

--- a/app/src/main/java/com/example/myapplication/picday/presentation/write/content/WriteViewContent.kt
+++ b/app/src/main/java/com/example/myapplication/picday/presentation/write/content/WriteViewContent.kt
@@ -20,11 +20,25 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import com.example.myapplication.picday.presentation.write.photo.WritePhotoItem
 import com.example.myapplication.picday.presentation.write.state.WriteUiMode
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.ui.Alignment
+import coil3.compose.AsyncImage
+import coil3.request.ImageRequest
+import coil3.request.crossfade
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.draw.clip
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 
 @Composable
 fun ColumnScope.WriteContent(
     uiMode: WriteUiMode,
     coverPhotoUri: String?,
+    viewModePhotoUris: List<String> = emptyList(),
     items: List<DiaryUiItem>,
     title: String,
     content: String,
@@ -39,6 +53,7 @@ fun ColumnScope.WriteContent(
     if (uiMode == WriteUiMode.VIEW) {
         WriteViewContent(
             coverPhotoUri = coverPhotoUri,
+            viewModePhotoUris = viewModePhotoUris,
             items = items,
             onAddClick = onAddClick,
             onEditClick = { diary -> onEditClick(diary.id) }
@@ -60,13 +75,18 @@ fun ColumnScope.WriteContent(
 @Composable
 fun ColumnScope.WriteViewContent(
     coverPhotoUri: String?,
+    viewModePhotoUris: List<String> = emptyList(),
     items: List<DiaryUiItem>,
     onAddClick: () -> Unit,
     onEditClick: (DiaryUiItem) -> Unit
 ) {
     Spacer(modifier = Modifier.height(24.dp))
 
-    WriteCoverPhoto(coverPhotoUri = coverPhotoUri)
+    if (viewModePhotoUris.size > 1) {
+        WritePhotoPager(photoUris = viewModePhotoUris)
+    } else {
+        WriteCoverPhoto(coverPhotoUri = coverPhotoUri)
+    }
 
     Spacer(modifier = Modifier.height(32.dp))
 
@@ -123,6 +143,45 @@ fun ColumnScope.WriteViewContent(
             Icon(imageVector = Icons.Default.Add, contentDescription = null, modifier = Modifier.size(20.dp))
             Spacer(modifier = Modifier.width(8.dp))
             Text("기록 추가하기", style = MaterialTheme.typography.titleSmall)
+        }
+    }
+}
+
+@Composable
+fun WritePhotoPager(photoUris: List<String>) {
+    val pagerState = rememberPagerState(pageCount = { photoUris.size })
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(260.dp), // 기존 CoverPhoto(220dp)보다 약간 더 키워서 존재감 부여
+        contentAlignment = Alignment.Center
+    ) {
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier.fillMaxSize(),
+            pageSpacing = 16.dp, // 페이지 간 간격
+            beyondViewportPageCount = 1
+        ) { page ->
+            val uri = photoUris[page]
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 24.dp) // 좌우 여백을 주어 다음 사진이 살짝 보이게 하거나 깔끔하게 중앙 배치
+                    .clip(RoundedCornerShape(24.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
+                contentAlignment = Alignment.Center
+            ) {
+                AsyncImage(
+                    model = ImageRequest.Builder(LocalContext.current)
+                        .data(uri)
+                        .crossfade(true)
+                        .build(),
+                    contentDescription = "사진 ${page + 1}",
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## 무엇을 변경했는가?

다이어리 작성 화면 및 캘린더 배경 이미지 설정에서 사용되는  
Photo Picker 기반 갤러리 연동 로직을 정리하고,  
중복 선택·선택 취소·편집(EDIT) 모드 등 다양한 상황에서도  
안정적으로 동작하도록 구조를 개선했습니다.

기능 동작 자체는 유지하면서,  
출시를 고려한 **안정성과 유지보수성 강화**에 초점을 맞췄습니다.

---

## Presentation / UI 계층

### 갤러리 결과 처리 구조화
- 각 화면의 Composable 내부에  
  - `onImagePicked` (단일 선택)  
  - `onImagesPicked` (다중 선택)  
  함수를 정의하여 Photo Picker 콜백 로직을 의미 있는 단위로 분리
- `rememberLauncherForActivityResult` 내부 로직을 단순화하여  
  가독성과 역할 분리 개선
- 사진 선택을 취소한 경우 (`null` / `empty` 결과)  
  UI 및 상태 변화 없이 즉시 반환되도록 방어 코드 추가

---

### Write 화면 (다이어리 작성 / 편집)
- **“사진 추가하기” 버튼**을 통해 갤러리 다중 이미지 선택 가능
- 다중 선택된 사진이 썸네일 형태로 정상 표시되도록 유지
- 편집(EDIT) 모드에서도  
  기존 사진과 신규 선택 사진이 함께 표시되도록 검증

---

### Calendar 화면 (배경 이미지 설정)
- 배경 이미지 선택 시 **단일 이미지 선택 흐름 유지**
- 선택 취소 시 기존 배경 이미지가 유지되도록 처리
- 앱 재시작 이후에도 배경 이미지가 유지되도록  
  `takePersistableUriPermission` 동작을 재확인하고 안정성 검증

---

## 갤러리 결과 처리 개선
- Photo Picker 결과가 `null` 또는 `emptyList` 인 경우  
  불필요한 상태 업데이트를 방지하도록 즉시 반환
- 동일한 이미지가 여러 번 선택되는 경우를 방어
  - 단일 Picker 호출 내 중복 선택: `distinct()`
  - 기존 이미지와 신규 선택 이미지 간 중복 비교 후 차단
- 이미지 추가/병합 로직을 UI 계층에서 제거하고  
  ViewModel 중심으로 정리

---

## Data 계층
- 이미지 URI는 기존 구조를 유지하여 `List<String>` 형태로 관리
- 별도의 데이터 모델 변경 없이 기존 저장/로드 흐름 재사용
- Calendar 배경 이미지의 경우  
  URI 접근 권한을 지속적으로 유지할 수 있도록 처리 방식 점검

---

## ViewModel 계층
- 갤러리에서 선택된 이미지 병합 로직을  
  `onPhotosAdded` 단일 진입점으로 통합
- 이미지 중복 체크, 필터링, 병합 로직을  
  ViewModel 책임으로 일원화하여 구조 안정성 강화
- 기존 사진(KEEP), 신규 사진(NEW), 삭제 대상(DELETE) 상태를 명확히 분리
- 편집(EDIT) 모드에서:
  - 삭제 시 UI에는 즉시 반영
  - 저장 시점에 최종 반영되도록 설계하여 안정적인 상태 관리 보장

---

## 왜 필요한가?
- Photo Picker 결과 처리 로직이 화면별로 분산되어 있어  
  유지보수 및 안정성 관리가 어려웠음
- 사진 선택 취소, 중복 선택, 편집 모드 등  
  실제 사용자 환경에서 발생 가능한 엣지 케이스를  
  명확히 방어할 필요가 있었음
- 기능 추가 없이 구조를 정리함으로써  
  출시를 고려한 안정적인 코드 베이스를 확보하고자 함

---

## 영향 범위
- `presentation/calendar/CalendarScreen.kt`
- `presentation/write/content/WriteEditContent.kt`
- `presentation/write/WriteViewModel.kt`

(기능 추가 없음, 기존 사용자 경험 유지)

---

## 리팩토링 원칙
- 기존 화면 구조와 사용자 흐름을 유지한 상태에서 안정성 개선
- UI는 사용자 입력과 결과 전달만 담당
- 상태 병합 및 비즈니스 로직은 ViewModel에서 일관되게 처리
- Photo Picker 기반 갤러리 흐름을 유지하여  
  권한 이슈 및 스토어 심사 리스크 최소화

---

## QA (Manual)
- 갤러리 열기 후 아무 사진도 선택하지 않고 닫았을 때 크래시가 발생하지 않는지 확인
- 동일한 사진을 여러 번 선택했을 때 중복으로 추가되지 않는지 확인
- 다중 사진 선택 시 썸네일이 모두 정상적으로 표시되는지 확인
- 편집(EDIT) 모드에서 기존 사진과 신규 사진이 함께 표시되는지 확인
- 사진 삭제 시 UI에 즉시 반영되는지 확인
- 저장 후 다시 진입했을 때 삭제되지 않은 사진만 유지되는지 확인
- Calendar 배경 이미지 선택 후 앱 재실행 시 설정이 유지되는지 확인

---

Fixes #19 
