### PR TITLE
refactor: Write 화면 IME 대응 개선 (LazyColumn + imePadding)

### DIFF
--- a/app/src/main/java/com/picday/diary/presentation/write/content/WriteEditContent.kt
+++ b/app/src/main/java/com/picday/diary/presentation/write/content/WriteEditContent.kt
@@ -252,7 +252,10 @@ fun ColumnScope.WriteEditContent(
                 ) {
                     OutlinedButton(
                         onClick = {
-                            val existingUris = photoItems.map { it.uri }.toSet()
+                    val existingUris = photoItems
+                        .filter { it.state != WritePhotoState.DELETE }
+                        .map { it.uri }
+                        .toSet()
                             val sampleRes = listOf(
                                 R.drawable.sample_photo_1,
                                 R.drawable.sample_photo_2,


### PR DESCRIPTION
## 변경 내용
Write 화면에서 키보드(IME) 노출 시 입력 필드가 가려지던 문제를 개선했습니다.
Jetpack Compose의 권장 방식에 따라 레이아웃 구조를 LazyColumn 기반으로 리팩터링했습니다.

## 주요 변경 사항

### Presentation Layer
- WriteScreen / WriteEditContent 레이아웃을 Column → LazyColumn으로 변경
- 루트 컨테이너에 Modifier.imePadding() 적용하여 키보드 노출 시 화면 자동 리사이즈
- 각 UI 영역(커버 사진, 액션바, 썸네일, 입력 필드)을 LazyColumn의 item 단위로 분리

### 입력 필드 레이아웃 개선
- 본문 입력 TextField에서 weight(1f) 제거
- defaultMinHeight(min = 200.dp) 적용하여 자연스러운 높이 확장 및 스크롤 지원

## 개선 효과
- 키보드가 올라와도 포커스된 TextField가 자동으로 화면에 유지됨
- windowSoftInputMode 등 매니페스트 설정 없이 WindowInsets 기반으로 IME 처리
- 상단 사진/액션 영역은 스크롤 아웃되고 입력 영역은 안정적으로 유지됨

## 비고
- Compose의 BringIntoView + WindowInsets(IME) 메커니즘을 활용한 구조적 개선
- UI 동작 변경 외 기능 로직 변화 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized the write editor into a scrollable, sectioned layout for smoother navigation.
  * Redesigned the action bar with two balanced buttons separated by a divider for clearer actions.
  * Moved thumbnails to a horizontal scroller and now hide photos marked as removed.
  * Consolidated title and content inputs into a unified area with refreshed appearance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->