### PR TITLE
feat(diary): 다이어리 화면 날짜 좌우 이동 기능 추가

### DIFF
--- a/app/src/main/java/com/picday/diary/presentation/diary/DiaryRoot.kt
+++ b/app/src/main/java/com/picday/diary/presentation/diary/DiaryRoot.kt
@@ -78,7 +78,9 @@ fun DiaryRoot(
             DiaryScreen(
                 uiState = diaryState,
                 onWriteClick = onWriteClick,
-                onEditClick = onEditClick
+                onEditClick = onEditClick,
+                onPreviousDate = { diaryViewModel.moveDateBy(-1) },
+                onNextDate = { diaryViewModel.moveDateBy(1) }
             )
         }
         DiaryRootScreen.WRITE -> {

--- a/app/src/main/java/com/picday/diary/presentation/diary/DiaryScreen.kt
+++ b/app/src/main/java/com/picday/diary/presentation/diary/DiaryScreen.kt
@@ -4,6 +4,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,7 +27,9 @@ import java.util.Locale
 fun DiaryScreen(
     uiState: DiaryUiState,
     onWriteClick: (LocalDate, WriteMode) -> Unit = { _, _ -> },
-    onEditClick: (String) -> Unit = {}
+    onEditClick: (String) -> Unit = {},
+    onPreviousDate: () -> Unit = {},
+    onNextDate: () -> Unit = {}
 ) {
     Column(
         modifier = Modifier
@@ -35,16 +42,34 @@ fun DiaryScreen(
 
         // Header Section
         Column {
-            Text(
-                text = "${uiState.selectedDate.monthValue}월 ${uiState.selectedDate.dayOfMonth}일의 기록",
-                style = MaterialTheme.typography.headlineSmall.copy(
-                    fontWeight = FontWeight.Bold,
-                    fontSize = 24.sp,
-                    letterSpacing = (-1).sp
-                ),
-                color = MaterialTheme.colorScheme.onSurface
-            )
-            
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onPreviousDate) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                        contentDescription = "이전 날짜"
+                    )
+                }
+                Text(
+                    text = "${uiState.selectedDate.monthValue}월 ${uiState.selectedDate.dayOfMonth}일의 기록",
+                    style = MaterialTheme.typography.headlineSmall.copy(
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 24.sp,
+                        letterSpacing = (-1).sp
+                    ),
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                IconButton(onClick = onNextDate) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                        contentDescription = "다음 날짜"
+                    )
+                }
+            }
+
             val dayOfWeek = uiState.selectedDate.dayOfWeek.getDisplayName(
                 TextStyle.FULL,
                 Locale.KOREAN

--- a/app/src/main/java/com/picday/diary/presentation/diary/DiaryViewModel.kt
+++ b/app/src/main/java/com/picday/diary/presentation/diary/DiaryViewModel.kt
@@ -51,6 +51,11 @@ class DiaryViewModel @Inject constructor(
         updateUiForDate(date)
     }
 
+    fun moveDateBy(days: Long) {
+        val next = _uiState.value.selectedDate.plusDays(days)
+        updateUiForDate(next)
+    }
+
     fun hasAnyRecord(date: LocalDate): Boolean {
         return hasAnyRecordUseCase(date)
     }


### PR DESCRIPTION
## 변경 배경 (Why)

기존 다이어리 화면에서는 날짜 변경을 위해
항상 캘린더 화면으로 돌아가야 했습니다.

연속된 날짜의 기록을 더 자연스럽게 탐색할 수 있도록,
다이어리 화면 내부에서 날짜를 좌/우(±1일)로 이동할 수 있는
기능을 추가했습니다.

---

## 구현 방식 (How)

- 선택된 날짜는 `DiaryViewModel`이 단일 소스로 관리합니다.
- 캘린더에서 날짜를 선택해 진입하는 기존 흐름은 그대로 유지합니다.
- 다이어리 화면 내부에서는 좌/우 이동 시
  `moveDateBy()`를 호출해 해당 날짜의 데이터를 로드합니다.
- UI는 `uiState.selectedDate`와 `uiState.uiItems`만 관찰하도록 유지했습니다.

이를 통해 캘린더는 **진입점**, 다이어리 화면은 **날짜 탐색 UI**로
역할이 분리되며, 기존 구조와 충돌 없이 확장 가능합니다.

---

## 변경 내용 (What)

- ViewModel에 날짜 이동 함수 추가  
  `DiaryViewModel.kt`
- 다이어리 화면 상단에 좌/우 이동 버튼 추가 및 콜백 연결  
  `DiaryScreen.kt`
- DiaryRoot에서 ViewModel 이동 함수 연결  
  `DiaryRoot.kt`

---

## 결과

- 다이어리 화면에서 날짜를 좌/우로 이동 가능
- 해당 날짜의 기록이 즉시 로드됨
- 캘린더 진입 흐름과 충돌 없이 정상 동작

---

## 🔜 다음 단계 (범위 외)

- `DiaryViewModelTest`에 `moveDateBy()` 동작 테스트 추가
- 필요 시 날짜 이동 시점에 캘린더 선택 상태 동기화 여부 검토


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added date navigation controls to the diary header with left and right arrow buttons
  * Users can now seamlessly browse through previous and next diary entries directly from the header

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->