### PR TITLE
refactor: DiaryRepository suspend 전환 및 비차단 데이터 처리 구조 개선

### DIFF
--- a/app/src/main/java/com/picday/diary/data/diary/repository/RoomDiaryRepository.kt
+++ b/app/src/main/java/com/picday/diary/data/diary/repository/RoomDiaryRepository.kt
@@ -11,8 +11,6 @@ import com.picday.diary.domain.diary.Diary
 import com.picday.diary.domain.diary.DiaryPhoto
 import com.picday.diary.domain.repository.DiaryRepository
 import java.time.LocalDate
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.flow.map
 
 class RoomDiaryRepository(
@@ -20,8 +18,8 @@ class RoomDiaryRepository(
     private val diaryDao: DiaryDao,
     private val diaryPhotoDao: DiaryPhotoDao
 ) : DiaryRepository {
-    override fun getByDate(date: LocalDate): List<Diary> = runBlocking(Dispatchers.IO) {
-        diaryDao.getByDate(date.toEpochDay()).map { it.toDomain() }
+    override suspend fun getByDate(date: LocalDate): List<Diary> {
+        return diaryDao.getByDate(date.toEpochDay()).map { it.toDomain() }
     }
 
     override fun getDiariesStream(startDate: LocalDate, endDate: LocalDate): kotlinx.coroutines.flow.Flow<List<Diary>> {
@@ -31,25 +29,24 @@ class RoomDiaryRepository(
             }
     }
 
-    override suspend fun getPhotosSuspend(diaryId: String): List<DiaryPhoto> {
+    override suspend fun getPhotos(diaryId: String): List<DiaryPhoto> {
         return diaryPhotoDao.getByDiaryId(diaryId).map { it.toDomain() }
     }
 
-    override fun getDiariesByDateRange(startDate: LocalDate, endDate: LocalDate): List<Diary> =
-        runBlocking(Dispatchers.IO) {
-            diaryDao.getByDateRange(startDate.toEpochDay(), endDate.toEpochDay())
-                .map { it.toDomain() }
-        }
-
-    override fun getDiaryById(diaryId: String): Diary? = runBlocking(Dispatchers.IO) {
-        diaryDao.getById(diaryId)?.toDomain()
+    override suspend fun getDiariesByDateRange(startDate: LocalDate, endDate: LocalDate): List<Diary> {
+        return diaryDao.getByDateRange(startDate.toEpochDay(), endDate.toEpochDay())
+            .map { it.toDomain() }
     }
 
-    override fun addDiaryForDate(date: LocalDate, title: String?, content: String) {
+    override suspend fun getDiaryById(diaryId: String): Diary? {
+        return diaryDao.getById(diaryId)?.toDomain()
+    }
+
+    override suspend fun addDiaryForDate(date: LocalDate, title: String?, content: String) {
         addDiaryForDate(date, title, content, emptyList())
     }
 
-    override fun addDiaryForDate(
+    override suspend fun addDiaryForDate(
         date: LocalDate,
         title: String?,
         content: String,
@@ -71,31 +68,23 @@ class RoomDiaryRepository(
                 createdAt = baseTime + index
             )
         }
-        runBlocking(Dispatchers.IO) {
-            database.withTransaction {
-                diaryDao.insert(diary.toEntity())
-                if (photos.isNotEmpty()) {
-                    diaryPhotoDao.insertAll(photos)
-                }
+        database.withTransaction {
+            diaryDao.insert(diary.toEntity())
+            if (photos.isNotEmpty()) {
+                diaryPhotoDao.insertAll(photos)
             }
         }
     }
 
-    override fun updateDiary(diaryId: String, title: String?, content: String): Boolean {
-        return runBlocking(Dispatchers.IO) {
-            diaryDao.updateDiary(diaryId, title, content) > 0
-        }
+    override suspend fun updateDiary(diaryId: String, title: String?, content: String): Boolean {
+        return diaryDao.updateDiary(diaryId, title, content) > 0
     }
 
-    override fun hasAnyRecord(date: LocalDate): Boolean = runBlocking(Dispatchers.IO) {
-        diaryDao.existsByDate(date.toEpochDay())
+    override suspend fun hasAnyRecord(date: LocalDate): Boolean {
+        return diaryDao.existsByDate(date.toEpochDay())
     }
 
-    override fun getPhotos(diaryId: String): List<DiaryPhoto> = runBlocking(Dispatchers.IO) {
-        diaryPhotoDao.getByDiaryId(diaryId).map { it.toDomain() }
-    }
-
-    override fun replacePhotos(diaryId: String, photoUris: List<String>) {
+    override suspend fun replacePhotos(diaryId: String, photoUris: List<String>) {
         val baseTime = System.currentTimeMillis()
         val photos = photoUris.mapIndexed { index, uri ->
             DiaryPhotoEntity(
@@ -105,23 +94,19 @@ class RoomDiaryRepository(
                 createdAt = baseTime + index
             )
         }
-        runBlocking(Dispatchers.IO) {
-            database.withTransaction {
-                diaryPhotoDao.deleteByDiaryId(diaryId)
-                if (photos.isNotEmpty()) {
-                    diaryPhotoDao.insertAll(photos)
-                }
+        database.withTransaction {
+            diaryPhotoDao.deleteByDiaryId(diaryId)
+            if (photos.isNotEmpty()) {
+                diaryPhotoDao.insertAll(photos)
             }
         }
     }
 
-    override fun deleteDiary(diaryId: String) {
-        runBlocking(Dispatchers.IO) {
-            // Delete diary and related photos atomically.
-            database.withTransaction {
-                diaryPhotoDao.deleteByDiaryId(diaryId)
-                diaryDao.deleteById(diaryId)
-            }
+    override suspend fun deleteDiary(diaryId: String) {
+        // Delete diary and related photos atomically.
+        database.withTransaction {
+            diaryPhotoDao.deleteByDiaryId(diaryId)
+            diaryDao.deleteById(diaryId)
         }
     }
 }

--- a/app/src/main/java/com/picday/diary/domain/repository/DiaryRepository.kt
+++ b/app/src/main/java/com/picday/diary/domain/repository/DiaryRepository.kt
@@ -6,16 +6,15 @@ import kotlinx.coroutines.flow.Flow
 import java.time.LocalDate
 
 interface DiaryRepository {
-    fun getByDate(date: LocalDate): List<Diary>
-    fun getDiaryById(diaryId: String): Diary?
-    fun addDiaryForDate(date: LocalDate, title: String?, content: String)
-    fun addDiaryForDate(date: LocalDate, title: String?, content: String, photoUris: List<String>)
-    fun updateDiary(diaryId: String, title: String?, content: String): Boolean
-    fun hasAnyRecord(date: LocalDate): Boolean
-    fun getPhotos(diaryId: String): List<DiaryPhoto>
-    suspend fun getPhotosSuspend(diaryId: String): List<DiaryPhoto>
-    fun getDiariesByDateRange(startDate: LocalDate, endDate: LocalDate): List<Diary> // 범위 쿼리 추가
+    suspend fun getByDate(date: LocalDate): List<Diary>
+    suspend fun getDiaryById(diaryId: String): Diary?
+    suspend fun addDiaryForDate(date: LocalDate, title: String?, content: String)
+    suspend fun addDiaryForDate(date: LocalDate, title: String?, content: String, photoUris: List<String>)
+    suspend fun updateDiary(diaryId: String, title: String?, content: String): Boolean
+    suspend fun hasAnyRecord(date: LocalDate): Boolean
+    suspend fun getPhotos(diaryId: String): List<DiaryPhoto>
+    suspend fun getDiariesByDateRange(startDate: LocalDate, endDate: LocalDate): List<Diary> // 범위 쿼리 추가
     fun getDiariesStream(startDate: LocalDate, endDate: LocalDate): Flow<List<Diary>>
-    fun replacePhotos(diaryId: String, photoUris: List<String>)
-    fun deleteDiary(diaryId: String)
+    suspend fun replacePhotos(diaryId: String, photoUris: List<String>)
+    suspend fun deleteDiary(diaryId: String)
 }

--- a/app/src/main/java/com/picday/diary/domain/usecase/diary/AddDiaryForDateUseCase.kt
+++ b/app/src/main/java/com/picday/diary/domain/usecase/diary/AddDiaryForDateUseCase.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 class AddDiaryForDateUseCase @Inject constructor(
     private val repository: DiaryRepository
 ) {
-    operator fun invoke(
+    suspend operator fun invoke(
         date: LocalDate,
         title: String?,
         content: String,

--- a/app/src/main/java/com/picday/diary/domain/usecase/diary/DeleteDiaryUseCase.kt
+++ b/app/src/main/java/com/picday/diary/domain/usecase/diary/DeleteDiaryUseCase.kt
@@ -6,7 +6,7 @@ import javax.inject.Inject
 class DeleteDiaryUseCase @Inject constructor(
     private val repository: DiaryRepository
 ) {
-    operator fun invoke(diaryId: String) {
+    suspend operator fun invoke(diaryId: String) {
         repository.deleteDiary(diaryId)
     }
 }

--- a/app/src/main/java/com/picday/diary/domain/usecase/diary/GetDiariesByDateRangeUseCase.kt
+++ b/app/src/main/java/com/picday/diary/domain/usecase/diary/GetDiariesByDateRangeUseCase.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 class GetDiariesByDateRangeUseCase @Inject constructor(
     private val repository: DiaryRepository
 ) {
-    operator fun invoke(startDate: LocalDate, endDate: LocalDate): List<Diary> {
+    suspend operator fun invoke(startDate: LocalDate, endDate: LocalDate): List<Diary> {
         return repository.getDiariesByDateRange(startDate, endDate)
     }
 }

--- a/app/src/main/java/com/picday/diary/domain/usecase/diary/GetDiariesByDateUseCase.kt
+++ b/app/src/main/java/com/picday/diary/domain/usecase/diary/GetDiariesByDateUseCase.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 class GetDiariesByDateUseCase @Inject constructor(
     private val repository: DiaryRepository
 ) {
-    operator fun invoke(date: LocalDate): List<Diary> {
+    suspend operator fun invoke(date: LocalDate): List<Diary> {
         return repository.getByDate(date)
     }
 }

--- a/app/src/main/java/com/picday/diary/domain/usecase/diary/GetDiaryByIdUseCase.kt
+++ b/app/src/main/java/com/picday/diary/domain/usecase/diary/GetDiaryByIdUseCase.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 class GetDiaryByIdUseCase @Inject constructor(
     private val repository: DiaryRepository
 ) {
-    operator fun invoke(diaryId: String): Diary? {
+    suspend operator fun invoke(diaryId: String): Diary? {
         return repository.getDiaryById(diaryId)
     }
 }

--- a/app/src/main/java/com/picday/diary/domain/usecase/diary/GetPhotosUseCase.kt
+++ b/app/src/main/java/com/picday/diary/domain/usecase/diary/GetPhotosUseCase.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 class GetPhotosUseCase @Inject constructor(
     private val repository: DiaryRepository
 ) {
-    operator fun invoke(diaryId: String): List<DiaryPhoto> {
+    suspend operator fun invoke(diaryId: String): List<DiaryPhoto> {
         return repository.getPhotos(diaryId)
     }
 }

--- a/app/src/main/java/com/picday/diary/domain/usecase/diary/HasAnyRecordUseCase.kt
+++ b/app/src/main/java/com/picday/diary/domain/usecase/diary/HasAnyRecordUseCase.kt
@@ -7,7 +7,7 @@ import javax.inject.Inject
 class HasAnyRecordUseCase @Inject constructor(
     private val repository: DiaryRepository
 ) {
-    operator fun invoke(date: LocalDate): Boolean {
+    suspend operator fun invoke(date: LocalDate): Boolean {
         return repository.hasAnyRecord(date)
     }
 }

--- a/app/src/main/java/com/picday/diary/domain/usecase/diary/ReplacePhotosUseCase.kt
+++ b/app/src/main/java/com/picday/diary/domain/usecase/diary/ReplacePhotosUseCase.kt
@@ -6,7 +6,7 @@ import javax.inject.Inject
 class ReplacePhotosUseCase @Inject constructor(
     private val repository: DiaryRepository
 ) {
-    operator fun invoke(diaryId: String, photoUris: List<String>) {
+    suspend operator fun invoke(diaryId: String, photoUris: List<String>) {
         repository.replacePhotos(diaryId, photoUris)
     }
 }

--- a/app/src/main/java/com/picday/diary/domain/usecase/diary/UpdateDiaryUseCase.kt
+++ b/app/src/main/java/com/picday/diary/domain/usecase/diary/UpdateDiaryUseCase.kt
@@ -6,7 +6,7 @@ import javax.inject.Inject
 class UpdateDiaryUseCase @Inject constructor(
     private val repository: DiaryRepository
 ) {
-    operator fun invoke(diaryId: String, title: String?, content: String): Boolean {
+    suspend operator fun invoke(diaryId: String, title: String?, content: String): Boolean {
         return repository.updateDiary(diaryId, title, content)
     }
 }

--- a/app/src/main/java/com/picday/diary/presentation/diary/DiaryViewModel.kt
+++ b/app/src/main/java/com/picday/diary/presentation/diary/DiaryViewModel.kt
@@ -58,7 +58,7 @@ class DiaryViewModel @Inject constructor(
         updateUiForDate(next)
     }
 
-    fun hasAnyRecord(date: LocalDate): Boolean {
+    suspend fun hasAnyRecord(date: LocalDate): Boolean {
         return hasAnyRecordUseCase(date)
     }
 

--- a/app/src/main/java/com/picday/diary/presentation/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/picday/diary/presentation/navigation/MainNavHost.kt
@@ -37,20 +37,26 @@ fun MainNavHost(
          * -------------------------------- */
         composable(Screen.Calendar.route) {
             val diaryViewModel: DiaryViewModel = hiltViewModel()
+            var pendingNavigateDate by remember { mutableStateOf<LocalDate?>(null) }
+
+            LaunchedEffect(pendingNavigateDate) {
+                val date = pendingNavigateDate ?: return@LaunchedEffect
+                val mode = if (diaryViewModel.hasAnyRecord(date)) {
+                    WriteMode.VIEW
+                } else {
+                    WriteMode.ADD
+                }
+
+                navController.navigate(
+                    Screen.Write.createRoute(date, mode)
+                )
+                pendingNavigateDate = null
+            }
 
             CalendarScreen(
                 onDateSelected = { date ->
                     sharedViewModel.updateSelectedDate(date)
-
-                    val mode = if (diaryViewModel.hasAnyRecord(date)) {
-                        WriteMode.VIEW
-                    } else {
-                        WriteMode.ADD
-                    }
-
-                    navController.navigate(
-                        Screen.Write.createRoute(date, mode)
-                    )
+                    pendingNavigateDate = date
                 }
             )
         }

--- a/app/src/main/java/com/picday/diary/widget/CalendarRemoteViewsFactory.kt
+++ b/app/src/main/java/com/picday/diary/widget/CalendarRemoteViewsFactory.kt
@@ -116,7 +116,7 @@ class CalendarRemoteViewsFactory(
                 val coverKey = stringPreferencesKey("cover_$date")
                 val coverUri = preferences?.get(coverKey)
                 val fallbackUri = if (coverUri == null) {
-                    diaryRepository.getPhotosSuspend(representativeDiary.id).firstOrNull()?.uri
+                    diaryRepository.getPhotos(representativeDiary.id).firstOrNull()?.uri
                 } else {
                     null
                 }

--- a/app/src/main/java/com/picday/diary/widget/CalendarWidgetProvider.kt
+++ b/app/src/main/java/com/picday/diary/widget/CalendarWidgetProvider.kt
@@ -11,6 +11,7 @@ import android.os.Bundle
 import android.widget.RemoteViews
 import android.util.Log
 import androidx.core.content.edit
+import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.stringPreferencesKey
 import coil3.ImageLoader
 import coil3.request.ImageRequest
@@ -133,7 +134,7 @@ class CalendarWidgetProvider : AppWidgetProvider() {
         val backgroundKey = stringPreferencesKey("calendar_background_uri")
         val backgroundUriString = try {
             context.dataStore.data
-                .map { preferences -> preferences[backgroundKey] }
+                .map { preferences: Preferences -> preferences[backgroundKey] }
                 .first()
         } catch (e: Exception) {
             Log.w("CalendarWidget", "Failed to read background photo from DataStore", e)
@@ -211,7 +212,7 @@ class CalendarWidgetProvider : AppWidgetProvider() {
         val dateKey = stringPreferencesKey("cover_${today}")
         val coverUriString = try {
             context.dataStore.data
-                .map { preferences -> preferences[dateKey] }
+                .map { preferences: Preferences -> preferences[dateKey] }
                 .first()
         } catch (e: Exception) {
             Log.w("CalendarWidget", "Failed to read cover photo from DataStore", e)

--- a/app/src/test/java/com/example/myapplication/diary/domain/usecase/diary/DiaryUseCaseTest.kt
+++ b/app/src/test/java/com/example/myapplication/diary/domain/usecase/diary/DiaryUseCaseTest.kt
@@ -10,6 +10,7 @@ import com.picday.diary.domain.usecase.diary.HasAnyRecordUseCase
 import com.picday.diary.domain.usecase.diary.ReplacePhotosUseCase
 import com.picday.diary.domain.usecase.diary.UpdateDiaryUseCase
 import com.picday.diary.fakes.FakeDiaryRepository
+import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
@@ -47,7 +48,7 @@ class DiaryUseCaseTest {
     }
 
     @Test
-    fun `사진 없이 추가하면 사진이 생성되지 않는다`() {
+    fun `사진 없이 추가하면 사진이 생성되지 않는다`() = runTest {
         val date = LocalDate.of(2024, 1, 1)
         addDiaryForDate(date, "Title", "Content")
 
@@ -57,7 +58,7 @@ class DiaryUseCaseTest {
     }
 
     @Test
-    fun `사진 포함 추가 시 사진이 생성된다`() {
+    fun `사진 포함 추가 시 사진이 생성된다`() = runTest {
         val date = LocalDate.of(2024, 1, 2)
         addDiaryForDate(date, "Title", "Content", listOf("uri1", "uri2"))
 
@@ -68,7 +69,7 @@ class DiaryUseCaseTest {
     }
 
     @Test
-    fun `조회와 업데이트 삭제가 정상 동작해야 한다`() {
+    fun `조회와 업데이트 삭제가 정상 동작해야 한다`() = runTest {
         val date = LocalDate.of(2024, 1, 3)
         addDiaryForDate(date, "Title", "Content", listOf("uri1"))
         val diaryId = getDiariesByDate(date).first().id
@@ -88,7 +89,7 @@ class DiaryUseCaseTest {
     }
 
     @Test
-    fun `기간 조회는 범위 내 기록만 반환한다`() {
+    fun `기간 조회는 범위 내 기록만 반환한다`() = runTest {
         val start = LocalDate.of(2024, 2, 1)
         val end = LocalDate.of(2024, 2, 3)
         addDiaryForDate(start, "D1", "C1")

--- a/app/src/test/java/com/example/myapplication/diary/fakes/FakeDiaryRepository.kt
+++ b/app/src/test/java/com/example/myapplication/diary/fakes/FakeDiaryRepository.kt
@@ -13,20 +13,20 @@ class FakeDiaryRepository : DiaryRepository {
     private val photos = mutableListOf<DiaryPhoto>()
     private val diariesFlow = MutableStateFlow<List<Diary>>(emptyList())
 
-    override fun getByDate(date: LocalDate): List<Diary> {
+    override suspend fun getByDate(date: LocalDate): List<Diary> {
         return diaries.filter { it.date == date }
     }
 
-    override fun getDiaryById(diaryId: String): Diary? {
+    override suspend fun getDiaryById(diaryId: String): Diary? {
         return diaries.find { it.id == diaryId }
     }
 
-    override fun addDiaryForDate(date: LocalDate, title: String?, content: String) {
+    override suspend fun addDiaryForDate(date: LocalDate, title: String?, content: String) {
         diaries.add(Diary(UUID.randomUUID().toString(), date, title, content, System.currentTimeMillis()))
         notifyDiaryChanged()
     }
 
-    override fun addDiaryForDate(date: LocalDate, title: String?, content: String, photoUris: List<String>) {
+    override suspend fun addDiaryForDate(date: LocalDate, title: String?, content: String, photoUris: List<String>) {
         val diaryId = UUID.randomUUID().toString()
         diaries.add(Diary(diaryId, date, title, content, System.currentTimeMillis()))
         photoUris.forEach { uri ->
@@ -35,7 +35,7 @@ class FakeDiaryRepository : DiaryRepository {
         notifyDiaryChanged()
     }
 
-    override fun updateDiary(diaryId: String, title: String?, content: String): Boolean {
+    override suspend fun updateDiary(diaryId: String, title: String?, content: String): Boolean {
         val index = diaries.indexOfFirst { it.id == diaryId }
         if (index != -1) {
             val old = diaries[index]
@@ -46,19 +46,15 @@ class FakeDiaryRepository : DiaryRepository {
         return false
     }
 
-    override fun hasAnyRecord(date: LocalDate): Boolean {
+    override suspend fun hasAnyRecord(date: LocalDate): Boolean {
         return diaries.any { it.date == date }
     }
 
-    override fun getPhotos(diaryId: String): List<DiaryPhoto> {
+    override suspend fun getPhotos(diaryId: String): List<DiaryPhoto> {
         return photos.filter { it.diaryId == diaryId }
     }
 
-    override suspend fun getPhotosSuspend(diaryId: String): List<DiaryPhoto> {
-        return getPhotos(diaryId)
-    }
-
-    override fun getDiariesByDateRange(startDate: LocalDate, endDate: LocalDate): List<Diary> {
+    override suspend fun getDiariesByDateRange(startDate: LocalDate, endDate: LocalDate): List<Diary> {
         return diaries.filter { it.date in startDate..endDate }
     }
 
@@ -66,7 +62,7 @@ class FakeDiaryRepository : DiaryRepository {
         return diariesFlow
     }
 
-    override fun replacePhotos(diaryId: String, photoUris: List<String>) {
+    override suspend fun replacePhotos(diaryId: String, photoUris: List<String>) {
         photos.removeAll { it.diaryId == diaryId }
         photoUris.forEach { uri ->
             photos.add(DiaryPhoto(UUID.randomUUID().toString(), diaryId, uri, System.currentTimeMillis()))
@@ -74,7 +70,7 @@ class FakeDiaryRepository : DiaryRepository {
         notifyDiaryChanged()
     }
 
-    override fun deleteDiary(diaryId: String) {
+    override suspend fun deleteDiary(diaryId: String) {
         diaries.removeAll { it.id == diaryId }
         photos.removeAll { it.diaryId == diaryId }
         notifyDiaryChanged()

--- a/app/src/test/java/com/example/myapplication/diary/presentation/diary/DiaryViewModelTest.kt
+++ b/app/src/test/java/com/example/myapplication/diary/presentation/diary/DiaryViewModelTest.kt
@@ -11,6 +11,7 @@ import com.picday.diary.domain.usecase.settings.GetDateCoverPhotoUseCase
 import com.picday.diary.domain.usecase.settings.SetDateCoverPhotoUseCase
 import com.picday.diary.util.MainDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.*
 import org.junit.Before
@@ -117,6 +118,7 @@ class DiaryViewModelTest {
             while (state.selectedDate != date || state.allPhotosForDate.isEmpty()) {
                 state = awaitItem()
             }
+            advanceUntilIdle()
             assertEquals("uri1", state.allPhotosForDate.firstOrNull())
             assertEquals("uri2", viewModel.coverPhotoByDate.value[date])
         }
@@ -141,7 +143,7 @@ class DiaryViewModelTest {
     }
 
     @Test
-    fun `hasAnyRecord는 기록 존재 여부를 반환해야 한다`() {
+    fun `hasAnyRecord는 기록 존재 여부를 반환해야 한다`() = runTest {
         val dateWithRecord = LocalDate.of(2024, 2, 1)
         val emptyDate = LocalDate.of(2024, 2, 2)
         diaryRepository.addDiaryForDate(dateWithRecord, "Title", "Content")
@@ -154,6 +156,7 @@ class DiaryViewModelTest {
     fun `대표 사진 저장 시 coverPhotoByDate가 갱신되어야 한다`() = runTest {
         val date = LocalDate.of(2024, 3, 1)
         viewModel.saveDateCoverPhoto(date, "uri_saved")
+        advanceUntilIdle()
 
         assertEquals("uri_saved", viewModel.coverPhotoByDate.value[date])
     }

--- a/app/src/test/java/com/example/myapplication/diary/util/MainDispatcherRule.kt
+++ b/app/src/test/java/com/example/myapplication/diary/util/MainDispatcherRule.kt
@@ -2,16 +2,19 @@ package com.picday.diary.util
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.*
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainDispatcherRule(
-    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+    private val dispatcher: TestDispatcher = StandardTestDispatcher()
 ) : TestWatcher() {
     override fun starting(description: Description) {
-        Dispatchers.setMain(testDispatcher)
+        Dispatchers.setMain(dispatcher)
     }
 
     override fun finished(description: Description) {


### PR DESCRIPTION
## 개요
`DiaryRepository`의 모든 데이터 접근 함수를 `suspend` 함수로 전환하고,
이에 맞춰 UseCase, ViewModel, 테스트 코드를 전반적으로 수정했습니다.

이번 변경을 통해 데이터베이스 및 데이터 소스 작업을
블로킹 없이 안전하게 처리할 수 있는 비차단(non-blocking) 구조를 완성했습니다.

기능 및 사용자 동작에는 변경이 없으며, 구조 개선과 안정성 향상에 초점을 둔 리팩토링입니다.

---

## 주요 변경 사항

### 1. DiaryRepository 및 구현체 수정
- `DiaryRepository` 인터페이스의 모든 CRUD 함수에 `suspend` 키워드 추가
- `RoomDiaryRepository`에서 `runBlocking` 제거
  - `suspend` + `withTransaction` 기반 비차단 처리로 전환
- `InMemoryDiaryRepository`, `FakeDiaryRepository`를 인터페이스와 정합되도록 `suspend` 기반으로 수정

---

### 2. UseCase 수정
- `DiaryRepository`를 사용하는 모든 UseCase의 `invoke` 함수를 `suspend`로 변경
  - (`AddDiaryForDateUseCase`, `GetPhotosUseCase`, `HasAnyRecordUseCase` 등)
- 데이터 접근 흐름을 명확히 비동기 경계로 분리

---

### 3. ViewModel 및 UI 로직 수정
- `DiaryViewModel.hasAnyRecord`를 `suspend` 함수로 변경
- `CalendarScreen`에서 날짜 선택 시
  - `hasAnyRecord` 호출을 `LaunchedEffect` 내부로 이동
  - UI 스레드 블로킹 없이 화면 전환 로직 처리

---

### 4. 테스트 코드 수정 및 안정화
- `DiaryViewModelTest`, `DiaryUseCaseTest` 등에서
  - `runTest` 기반으로 `suspend` 함수 테스트
- 비동기 작업 완료 시점을 보장하기 위해 `advanceUntilIdle()` 적용
- `MainDispatcherRule`을 `StandardTestDispatcher` 기반으로 수정하여
  - 테스트에서 시간 제어 및 안정성 확보

---

## 참고 사항
- AppWidget(RemoteViews) 영역은 플랫폼 제약으로 인해
  동기 처리가 필요한 부분(`runBlocking`)을 유지했습니다.
- 기능/동작 변경 없이 구조 개선만 수행한 리팩토링입니다.

---

## 결과
- 전체 빌드 및 테스트 통과
- 비차단 데이터 처리 구조 확립
- 코루틴 기반 아키텍처 일관성 및 테스트 신뢰성 향상


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Calendar date selection now intelligently opens diary entries in view mode if records exist, otherwise opens in add mode.

* **Refactor**
  - Backend operations now use asynchronous patterns for improved responsiveness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->