### PR TITLE
refactor: navigation 순수 모델(core) 분리 및 구조 정리 기반 마련

### DIFF
--- a/app/src/main/java/com/picday/diary/core/navigation/AppRoute.kt
+++ b/app/src/main/java/com/picday/diary/core/navigation/AppRoute.kt
@@ -1,0 +1,3 @@
+package com.picday.diary.core.navigation
+
+interface AppRoute

--- a/app/src/main/java/com/picday/diary/core/navigation/NavEffect.kt
+++ b/app/src/main/java/com/picday/diary/core/navigation/NavEffect.kt
@@ -1,0 +1,3 @@
+package com.picday.diary.core.navigation
+
+interface NavEffect

--- a/app/src/main/java/com/picday/diary/core/navigation/NavEvent.kt
+++ b/app/src/main/java/com/picday/diary/core/navigation/NavEvent.kt
@@ -1,0 +1,3 @@
+package com.picday.diary.core.navigation
+
+interface NavEvent

--- a/app/src/main/java/com/picday/diary/core/navigation/WriteMode.kt
+++ b/app/src/main/java/com/picday/diary/core/navigation/WriteMode.kt
@@ -1,0 +1,6 @@
+package com.picday.diary.core.navigation
+
+enum class WriteMode {
+    VIEW,
+    ADD
+}

--- a/app/src/main/java/com/picday/diary/presentation/diary/DiaryRoot.kt
+++ b/app/src/main/java/com/picday/diary/presentation/diary/DiaryRoot.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.platform.LocalContext
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.runtime.remember
-import com.picday.diary.presentation.navigation.WriteMode
+import com.picday.diary.core.navigation.WriteMode
 import com.picday.diary.presentation.write.WriteScreen
 import com.picday.diary.presentation.write.WriteViewModel
 import com.picday.diary.presentation.write.state.WriteUiMode

--- a/app/src/main/java/com/picday/diary/presentation/main/MainDestination.kt
+++ b/app/src/main/java/com/picday/diary/presentation/main/MainDestination.kt
@@ -2,9 +2,10 @@ package com.picday.diary.presentation.main
 
 import androidx.navigation3.runtime.NavKey
 import kotlinx.serialization.Serializable
+import com.picday.diary.core.navigation.AppRoute
 
 @Serializable
-sealed interface MainDestination : NavKey {
+sealed interface MainDestination : NavKey, AppRoute {
     @Serializable
     data object Calendar : MainDestination
 

--- a/app/src/main/java/com/picday/diary/presentation/main/MainNavReducer.kt
+++ b/app/src/main/java/com/picday/diary/presentation/main/MainNavReducer.kt
@@ -1,6 +1,6 @@
 package com.picday.diary.presentation.main
 
-import com.picday.diary.presentation.navigation.WriteMode
+import com.picday.diary.core.navigation.WriteMode
 import java.time.LocalDate
 
 sealed interface MainNavEvent {

--- a/app/src/main/java/com/picday/diary/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/picday/diary/presentation/main/MainScreen.kt
@@ -35,6 +35,7 @@ import androidx.navigation3.runtime.entryProvider
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
+import com.picday.diary.core.navigation.WriteMode
 import com.picday.diary.presentation.calendar.CalendarScreen
 import com.picday.diary.presentation.common.SharedViewModel
 import com.picday.diary.presentation.diary.DiaryRoot
@@ -43,7 +44,6 @@ import com.picday.diary.presentation.diary.DiaryViewModel
 import com.picday.diary.presentation.navigation.MainNavEvent
 import com.picday.diary.presentation.navigation.NavigationRoot
 import com.picday.diary.presentation.navigation.Screen
-import com.picday.diary.presentation.navigation.WriteMode
 import com.picday.diary.presentation.theme.AppColors
 import com.picday.diary.presentation.theme.AppShapes
 import java.time.LocalDate

--- a/app/src/main/java/com/picday/diary/presentation/navigation/MainNavGraph.kt
+++ b/app/src/main/java/com/picday/diary/presentation/navigation/MainNavGraph.kt
@@ -1,11 +1,14 @@
 package com.picday.diary.presentation.navigation
 
 import android.net.Uri
+import com.picday.diary.core.navigation.NavEffect
+import com.picday.diary.core.navigation.NavEvent
+import com.picday.diary.core.navigation.WriteMode
 import com.picday.diary.presentation.main.MainDestination
 import java.time.LocalDate
 
 // Navigation 이벤트를 나타내는 sealed interface
-sealed interface MainNavEvent {
+sealed interface MainNavEvent : NavEvent {
     // 하단 탭 클릭 이벤트
     data class BottomTabClick(val target: MainDestination) : MainNavEvent
     // 캘린더 날짜 선택 이벤트
@@ -27,7 +30,7 @@ sealed interface MainNavEvent {
 }
 
 // Navigation 부수 효과를 나타내는 sealed interface
-sealed interface MainNavEffect {
+sealed interface MainNavEffect : NavEffect {
     // 현재 화면 하나를 스택에서 제거
     data object PopOne : MainNavEffect
     // 스택의 최상위 화면까지 모두 제거

--- a/app/src/main/java/com/picday/diary/presentation/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/picday/diary/presentation/navigation/MainNavHost.kt
@@ -10,6 +10,7 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import com.picday.diary.core.navigation.WriteMode
 import com.picday.diary.presentation.calendar.CalendarScreen
 import com.picday.diary.presentation.common.SharedViewModel
 import com.picday.diary.presentation.diary.DiaryRoot

--- a/app/src/main/java/com/picday/diary/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/picday/diary/presentation/navigation/Screen.kt
@@ -5,6 +5,7 @@ import androidx.compose.material.icons.outlined.CalendarToday
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.ui.graphics.vector.ImageVector
 import android.net.Uri
+import com.picday.diary.core.navigation.WriteMode
 import java.time.LocalDate
 
 sealed class Screen(val route: String, val title: String, val icon: ImageVector) {

--- a/app/src/main/java/com/picday/diary/presentation/navigation/WriteMode.kt
+++ b/app/src/main/java/com/picday/diary/presentation/navigation/WriteMode.kt
@@ -1,6 +1,0 @@
-package com.picday.diary.presentation.navigation
-
-enum class WriteMode {
-    VIEW,
-    ADD
-}

--- a/app/src/test/java/com/example/myapplication/diary/presentation/main/MainNavReducerTest.kt
+++ b/app/src/test/java/com/example/myapplication/diary/presentation/main/MainNavReducerTest.kt
@@ -1,6 +1,6 @@
 package com.picday.diary.presentation.main
 
-import com.picday.diary.presentation.navigation.WriteMode
+import com.picday.diary.core.navigation.WriteMode
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.LocalDate


### PR DESCRIPTION
## 개요
Navigation 구조 리팩토링을 위한 사전 작업으로,
core로 이동 가능한 순수 모델만 분리했습니다.

이번 PR은 구조 정리에만 초점을 맞추었으며,
네비게이션 동작/전환 로직에는 변경이 없습니다.

## 변경 내용
- `core/navigation` 패키지에 순수 네비게이션 모델 추가
  - `AppRoute`
  - `NavEvent`
  - `NavEffect`
  - `WriteMode`
- `WriteMode`를 presentation → core로 이동
- presentation/navigation 영역에서
  core 모델을 사용하도록 import 경로만 정리
- 기존 Navigation3 / NavHost / reducer 로직은 그대로 유지

## 제약 및 범위
- 실제 네비게이션 실행 로직 변경 ❌
- 화면 전환 방식 변경 ❌
- MVI 구조 재설계 ❌

## 비고
이번 PR은 이후 Navigation 이벤트/이펙트 흐름을
MVI 방식으로 정리하기 위한 기반 작업입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized navigation infrastructure by establishing core navigation types and improving the type hierarchy for better modularity and separation of concerns across the navigation layer.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->