### PR TITLE
refactor: NavigationState 도입 및 MVI 기반 네비게이션 흐름 정리

### DIFF
--- a/app/src/main/java/com/picday/diary/core/navigation/NavigationState.kt
+++ b/app/src/main/java/com/picday/diary/core/navigation/NavigationState.kt
@@ -1,0 +1,8 @@
+package com.picday.diary.core.navigation
+
+import java.time.LocalDate
+
+data class NavigationState(
+    val backStack: List<AppRoute>,
+    val selectedDate: LocalDate?
+)

--- a/app/src/main/java/com/picday/diary/presentation/diary/DiaryScreen.kt
+++ b/app/src/main/java/com/picday/diary/presentation/diary/DiaryScreen.kt
@@ -17,8 +17,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.picday.diary.core.navigation.WriteMode
 import com.picday.diary.presentation.component.DiaryItemCard
-import com.picday.diary.presentation.navigation.WriteMode
 import java.time.LocalDate
 import java.time.format.TextStyle
 import java.util.Locale

--- a/app/src/main/java/com/picday/diary/presentation/main/MainScreen.kt
+++ b/app/src/main/java/com/picday/diary/presentation/main/MainScreen.kt
@@ -174,7 +174,6 @@ fun MainScreen(deepLinkUri: String? = null) {
 
                         CalendarScreen(
                             onDateSelected = { date ->
-                                sharedViewModel.updateSelectedDate(date)
                                 pendingNavigateDate = date
                             }
                         )

--- a/app/src/main/java/com/picday/diary/presentation/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/picday/diary/presentation/navigation/MainNavHost.kt
@@ -56,7 +56,6 @@ fun MainNavHost(
 
             CalendarScreen(
                 onDateSelected = { date ->
-                    sharedViewModel.updateSelectedDate(date)
                     pendingNavigateDate = date
                 }
             )


### PR DESCRIPTION
## 개요
NavigationState를 명시적으로 도입하고,
네비게이션 흐름을 (NavigationState, NavEvent) → (NavigationState, NavEffect)
형태의 MVI 구조로 정리했습니다.

모든 네비게이션 상태 변경은 reducer를 통해서만 발생하며,
실제 side effect(백스택 변경, 날짜 갱신 등)는 NavigationRoot에서만 실행됩니다.
화면 전환 및 사용자 동작은 기존과 동일하게 유지됩니다.

## 변경 내용
- `NavigationState` 모델 도입
- `MainNavGraph`의 reducer를
  `(NavigationState, NavEvent) -> (NavigationState, NavEffect)` 구조로 정리
- 네비게이션 관련 side effect 생성 책임을 reducer로 이동
- `NavigationRoot`에서 NavEffect만을 소비하여
  실제 Navigation3 백스택 및 선택 날짜 갱신 실행
- `SharedViewModel`에서 날짜 직접 갱신 호출 제거
  (UpdateSelectedDate 이펙트 경유)
- `WriteMode`를 core/navigation으로 이동하고,
  모든 사용처 import 경로 정합성 수정
  (`DiaryScreen` 포함)

## 확인 포인트
- 모든 네비게이션 상태 변경은 `reduceMainNav(...)`를 통해서만 발생
- ViewModel에서 네비게이션/날짜 변경 side effect 직접 실행 제거
- NavigationRoot가 side effect 실행의 단일 책임 지점
- 화면 전환 및 UI 동작은 기존과 완전히 동일

## 제약 및 범위
- Navigation3 구조 변경  X
- 화면 전환 로직 변경 X
- UI 상태 모델 추가 X
- 설계 철학 변경 X



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved navigation state management to better retain app state during navigation flows.
  * Enhanced date selection handling by streamlining how selected dates are tracked and synchronized with navigation.
  * Reorganized navigation logic to use state-based architecture for more predictable behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->