### PR TITLE
refactor: Navigation 구조 정리 및 Screen 메타 분리 (#24)

### DIFF
--- a/app/src/main/java/com/picday/diary/presentation/navigation/Screen.kt
+++ b/app/src/main/java/com/picday/diary/presentation/navigation/Screen.kt
@@ -1,17 +1,18 @@
 package com.picday.diary.presentation.navigation
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.CalendarToday
-import androidx.compose.material.icons.outlined.Edit
-import androidx.compose.ui.graphics.vector.ImageVector
 import android.net.Uri
 import com.picday.diary.core.navigation.WriteMode
 import java.time.LocalDate
 
-sealed class Screen(val route: String, val title: String, val icon: ImageVector) {
-    object Calendar : Screen("calendar", "Calendar", Icons.Outlined.CalendarToday)
-    object Diary : Screen("diary", "Diary", Icons.Outlined.Edit)
-    object Write : Screen("write/{date}/{mode}", "Write", Icons.Outlined.Edit) {
+sealed class Screen(val meta: ScreenMeta) {
+    val route: String get() = meta.route
+    val title: String get() = meta.title
+    val icon get() = meta.icon
+    val deepLink get() = meta.deepLink
+
+    object Calendar : Screen(ScreenMetaRegistry.Calendar)
+    object Diary : Screen(ScreenMetaRegistry.Diary)
+    object Write : Screen(ScreenMetaRegistry.Write) {
         fun createRoute(date: LocalDate, mode: WriteMode): String {
             return "write/${Uri.encode(date.toString())}/${mode.name}"
         }

--- a/app/src/main/java/com/picday/diary/presentation/navigation/ScreenMeta.kt
+++ b/app/src/main/java/com/picday/diary/presentation/navigation/ScreenMeta.kt
@@ -1,0 +1,37 @@
+package com.picday.diary.presentation.navigation
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.CalendarToday
+import androidx.compose.material.icons.outlined.Edit
+import androidx.compose.ui.graphics.vector.ImageVector
+
+// UI/Navigation이 참고하는 정적 정의
+sealed interface ScreenMeta {
+    val route: String
+    val title: String
+    val icon: ImageVector
+    val deepLink: String?
+}
+
+object ScreenMetaRegistry {
+    object Calendar : ScreenMeta {
+        override val route = "calendar"
+        override val title = "Calendar"
+        override val icon = Icons.Outlined.CalendarToday
+        override val deepLink: String? = null
+    }
+
+    object Diary : ScreenMeta {
+        override val route = "diary"
+        override val title = "Diary"
+        override val icon = Icons.Outlined.Edit
+        override val deepLink: String? = null
+    }
+
+    object Write : ScreenMeta {
+        override val route = "write/{date}/{mode}"
+        override val title = "Write"
+        override val icon = Icons.Outlined.Edit
+        override val deepLink: String? = null
+    }
+}


### PR DESCRIPTION
## 무엇을 변경했는가?
PicDay 앱의 Navigation 구조를 정리하며,  
`Screen / Destination`이 동시에 담당하던 **의미(정적 메타)**와 **동작(라우팅/헬퍼)**을  
명확히 분리하는 리팩토링의 **마지막 단계**를 완료했습니다.

본 PR은 네비게이션 동작, reducer/effect 로직, 화면 전환 결과에는  
**어떠한 기능적 변경도 가하지 않았으며**,  
구조적 명확성과 확장성 개선에만 집중합니다.

---

## 주요 변경 사항

### 1. Screen 메타 정보 분리
- `ScreenMeta` 모델 도입
  - route / title / icon / (정적) deepLink 정의
- `Screen`은 `ScreenMeta`를 참조하도록 구조 변경
  - Screen의 책임을 **동작/헬퍼 제공**으로 한정
  - 화면의 의미(메타)는 ScreenMeta가 담당하도록 분리

---

### 2. Navigation 구조 정리 (이전 PR 포함 흐름)
- `NavigationState` 명시적 도입
- reducer 시그니처를  
  `(NavigationState, NavEvent) -> (NavigationState, NavEffect)` 형태로 정리
- reducer는 **상태 계산 + 이펙트 생성**만 담당
- `NavigationRoot`가 `NavEffect`를 받아
  실제 Navigation3 백스택 변경 및 날짜 갱신 실행
- ViewModel에서 네비게이션/날짜 변경 side effect 직접 실행 제거

---

## 현재 Navigation 구조 요약

```text
[ ScreenMeta ]
- 화면의 정적 의미 정의
  (route / title / icon / deepLink)

[ Screen ]
- ScreenMeta 참조
- route / argument 헬퍼 제공
- 화면 식별자 역할

[ NavEvent ]
- 사용자 입력 / 시스템 이벤트

[ Reducer ]
- (NavigationState, NavEvent)
  -> (NavigationState, NavEffect)

[ NavEffect ]
- Navigate / Pop / PopToRoot / UpdateSelectedDate 등
- “무엇을 실행할지”만 표현

[ NavigationRoot ]
- NavEffect를 실제 Navigation3 동작으로 실행
- side effect 실행의 단일 책임 지점


Closes #62 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored the navigation system's metadata management by introducing a centralized registry that consolidates all screen definitions and properties. Navigation elements such as routes, titles, icons, and deep linking are now sourced from a unified, type-safe metadata model, improving code organization, maintainability, and consistency throughout the application's navigation infrastructure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->