### PR TITLE
test: ViewModel 및 UseCase 테스트 코드 추가 및 보완

### DIFF
--- a/app/src/test/java/com/example/myapplication/diary/domain/usecase/calendar/ObserveMonthlyDiariesUseCaseTest.kt
+++ b/app/src/test/java/com/example/myapplication/diary/domain/usecase/calendar/ObserveMonthlyDiariesUseCaseTest.kt
@@ -1,0 +1,96 @@
+package com.example.myapplication.diary.domain.usecase.calendar
+
+import com.picday.diary.domain.diary.Diary
+import com.picday.diary.domain.usecase.calendar.ObserveMonthlyDiariesUseCase
+import com.picday.diary.fakes.FakeDiaryRepository
+import com.picday.diary.fakes.FakeSettingsRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Test
+import java.time.LocalDate
+import java.time.YearMonth
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ObserveMonthlyDiariesUseCaseTest {
+
+    private lateinit var diaryRepository: FakeDiaryRepository
+    private lateinit var settingsRepository: FakeSettingsRepository
+    private lateinit var observeMonthlyDiariesUseCase: ObserveMonthlyDiariesUseCase
+
+    @Before
+    fun setUp() {
+        diaryRepository = FakeDiaryRepository()
+        settingsRepository = FakeSettingsRepository()
+        observeMonthlyDiariesUseCase = ObserveMonthlyDiariesUseCase(
+            diaryRepository = diaryRepository,
+            settingsRepository = settingsRepository
+        )
+    }
+
+    @Test
+    fun `saved cover is preferred and fallback uses latest diary photo when missing`() = runTest {
+        val yearMonth = YearMonth.of(2026, 1)
+        val dateWithCover = LocalDate.of(2026, 1, 5)
+        val dateWithFallback = LocalDate.of(2026, 1, 6)
+        val dateWithoutPhotos = LocalDate.of(2026, 1, 7)
+
+        diaryRepository.addDiary(
+            Diary(
+                id = "d1",
+                date = dateWithCover,
+                title = "t1",
+                content = "c1",
+                createdAt = 1L,
+                coverPhotoUri = "cover1"
+            )
+        )
+
+        diaryRepository.addDiaryForDate(dateWithFallback, "t2", "c2", listOf("uri1", "uri2"))
+        diaryRepository.addDiaryForDate(dateWithFallback, "t3", "c3", listOf("uri3"))
+        diaryRepository.addDiaryForDate(dateWithoutPhotos, "t4", "c4")
+
+        val result = observeMonthlyDiariesUseCase(yearMonth).first()
+
+        assertEquals("cover1", result[dateWithCover])
+        assertEquals("uri3", result[dateWithFallback])
+        assertFalse(result.containsKey(dateWithoutPhotos))
+    }
+
+    @Test
+    fun `emits empty then updates when diary is added`() = runTest {
+        val yearMonth = YearMonth.of(2026, 1)
+        val date = LocalDate.of(2026, 1, 2)
+        val emissions = mutableListOf<Map<LocalDate, String>>()
+
+        val job = launch {
+            observeMonthlyDiariesUseCase(yearMonth)
+                .take(2)
+                .toList(emissions)
+        }
+
+        advanceUntilIdle()
+        diaryRepository.addDiary(
+            Diary(
+                id = "d2",
+                date = date,
+                title = "t",
+                content = "c",
+                createdAt = 2L,
+                coverPhotoUri = "cover2"
+            )
+        )
+        advanceUntilIdle()
+        job.join()
+
+        assertEquals(true, emissions.first().isEmpty())
+        assertEquals("cover2", emissions.last()[date])
+    }
+}

--- a/app/src/test/java/com/example/myapplication/diary/presentation/calendar/CalendarViewModelTest.kt
+++ b/app/src/test/java/com/example/myapplication/diary/presentation/calendar/CalendarViewModelTest.kt
@@ -9,12 +9,15 @@ import com.picday.diary.fakes.FakeSettingsRepository
 import com.picday.diary.presentation.calendar.CalendarViewModel
 import com.picday.diary.util.MainDispatcherRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.time.LocalDate
+import java.time.YearMonth
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CalendarViewModelTest {
@@ -67,6 +70,73 @@ class CalendarViewModelTest {
             assertEquals(null, awaitItem())
             viewModel.setBackgroundUri("uri_bg")
             assertEquals("uri_bg", awaitItem())
+        }
+    }
+
+    @Test
+    fun `2026년 1월 신정과 일요일은 휴일로 표시된다`() {
+        moveToMonth(YearMonth.of(2026, 1))
+
+        val days = viewModel.uiState.value.calendarDays
+        val newYearDay = days.first { it.date == LocalDate.of(2026, 1, 1) }
+        assertEquals(true, newYearDay.isHoliday)
+        assertEquals("신정", newYearDay.holidayName)
+
+        val sunday = days.first { it.date.dayOfWeek.value == 7 }
+        assertEquals(true, sunday.isHoliday)
+    }
+
+    @Test
+    fun `2025년 12월의 평일은 휴일이 아니다`() {
+        moveToMonth(YearMonth.of(2025, 12))
+
+        val days = viewModel.uiState.value.calendarDays
+        val nonSunday = days.first { it.date.year == 2025 && it.date.monthValue == 12 && it.date.dayOfWeek.value != 7 }
+        assertEquals(false, nonSunday.isHoliday)
+        assertEquals(null, nonSunday.holidayName)
+    }
+
+    @Test
+    fun `2026년 각 월의 휴일 계산이 수행된다`() {
+        val holidayMonths = setOf(1, 2, 3, 5, 6, 8, 9, 10, 12)
+        for (month in 1..12) {
+            moveToMonth(YearMonth.of(2026, month))
+            val days = viewModel.uiState.value.calendarDays
+            assertNotNull(days)
+            if (month in holidayMonths) {
+                val hasHoliday = days.any { it.holidayName != null }
+                assertEquals(true, hasHoliday)
+            }
+        }
+    }
+
+    @Test
+    fun `월별 대표 사진 스트림이 coverPhotos에 반영된다`() = runTest {
+        val date = LocalDate.of(2026, 1, 3)
+        diaryRepository.addDiary(
+            com.picday.diary.domain.diary.Diary(
+                id = "cover_diary",
+                date = date,
+                title = "t",
+                content = "c",
+                createdAt = 1L,
+                coverPhotoUri = "cover_uri"
+            )
+        )
+
+        advanceUntilIdle()
+        assertEquals("cover_uri", viewModel.uiState.value.coverPhotos[date])
+    }
+
+    private fun moveToMonth(target: YearMonth) {
+        var current = viewModel.uiState.value.currentYearMonth
+        while (current < target) {
+            viewModel.onNextMonthClick()
+            current = viewModel.uiState.value.currentYearMonth
+        }
+        while (current > target) {
+            viewModel.onPreviousMonthClick()
+            current = viewModel.uiState.value.currentYearMonth
         }
     }
 }

--- a/app/src/test/java/com/example/myapplication/diary/presentation/common/SharedViewModelTest.kt
+++ b/app/src/test/java/com/example/myapplication/diary/presentation/common/SharedViewModelTest.kt
@@ -1,0 +1,19 @@
+package com.example.myapplication.diary.presentation.common
+
+import com.picday.diary.presentation.common.SharedViewModel
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.LocalDate
+
+class SharedViewModelTest {
+
+    @Test
+    fun `updateSelectedDate updates selectedDate state`() {
+        val viewModel = SharedViewModel()
+        val date = LocalDate.of(2026, 1, 15)
+
+        viewModel.updateSelectedDate(date)
+
+        assertEquals(date, viewModel.selectedDate.value)
+    }
+}

--- a/app/src/test/java/com/example/myapplication/diary/presentation/diary/DiaryViewModelTest.kt
+++ b/app/src/test/java/com/example/myapplication/diary/presentation/diary/DiaryViewModelTest.kt
@@ -171,6 +171,22 @@ class DiaryViewModelTest {
     }
 
     @Test
+    fun `coverPhotoByDate는 상태 변경을 방출한다`() = runTest {
+        val date = LocalDate.of(2024, 3, 2)
+        val testDiary = Diary("diary_id_5", date, "Title", "Content", System.currentTimeMillis())
+        diaryRepository.addDiary(testDiary)
+
+        viewModel.coverPhotoByDate.test {
+            val initial = awaitItem()
+            assertNull(initial[date])
+
+            viewModel.saveDateCoverPhoto(date, "uri_saved_2")
+            val updated = awaitItem()
+            assertEquals("uri_saved_2", updated[date])
+        }
+    }
+
+    @Test
     fun `preloadCoverPhotos는 저장된 대표 사진과 최신 사진을 우선 반영해야 한다`() = runTest {
         val dateWithSavedCover = LocalDate.of(2024, 4, 1)
         val dateWithDiary = LocalDate.of(2024, 4, 2)


### PR DESCRIPTION
### 변경 목적
각 ViewModel과 UseCase의 핵심 로직을 검증하고, 기존 테스트의 공백을 보완하여  
전체적인 테스트 커버리지와 코드 신뢰도를 개선했습니다.

Flow 기반 상태 변경, 날짜·사진 관련 분기 로직 등  
버그 발생 가능성이 높은 영역을 중심으로 단위 테스트를 대폭 보강했습니다.

---

### 주요 변경 사항

#### 신규 테스트 추가
- **`ObserveMonthlyDiariesUseCaseTest.kt`**
  - 월별 대표 사진 조회 시 저장된 `coverPhotoUri`를 우선 사용하고,
    없을 경우 최신 일기의 마지막 사진으로 fallback 되는 로직 검증
  - 일기 추가 시 초기의 비어있는 상태에서
    업데이트된 사진 맵을 올바르게 방출하는지 Flow 동작 검증

- **`SharedViewModelTest.kt`**
  - `updateSelectedDate` 호출 시
    `selectedDate` 상태가 정상적으로 갱신되는지 확인하는 기본 테스트 추가

---

#### 기존 테스트 보완
- **`CalendarViewModelTest.kt`**
  - 2026년 신정 및 특정 월의 공휴일이
    `isHoliday`로 올바르게 계산되는지 검증
  - 월 이동 후 `ObserveMonthlyDiariesUseCase`를 통해
    `coverPhotos` 상태가 정상적으로 업데이트되는지 확인

- **`DiaryViewModelTest.kt`**
  - `saveDateCoverPhoto` 호출에 따라
    `coverPhotoByDate` 상태가 변경 사항을 올바르게 방출하는지
    Flow 테스트로 검증

- **`WriteViewModelTest.kt`**
  - 사진 추가, 클릭, 삭제 시
    `photoItems` 순서와 `selectedCoverPhotoUri` 상태 변화 검증
  - `content://` URI 스키마를 가진 사진만
    `pendingReleaseUris`에 추가되는 로직 테스트
  - `getCoverPhotoUri`, `getRepresentativePhotoUriForExit`가
    선택된 사진 유/무 및 사진 목록 상태에 따라
    정확한 URI를 반환하는지 검증
  - `setMode`가 `ADD`, `EDIT`, `VIEW` 모드를
    올바르게 설정하는지 확인

---

### 테스트 범위 요약
- ViewModel의 StateFlow 상태 변화
- UseCase의 분기 및 fallback 로직
- 날짜·사진 관련 핵심 비즈니스 규칙
- Flow 방출 타이밍과 상태 일관성


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for monthly diary photo observations and calendar displays.
  * Added validation tests for calendar holidays and cover photo mapping.
  * New test suite for selected date state updates.
  * Extended tests for cover photo state management and emissions.
  * Enhanced tests for photo management workflows including add, remove, click, and save operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->