### PR TITLE
refactor: 지출(Expense) 관련 데이터 및 도메인 레이어 패키지 구조 개선

### DIFF
--- a/app/src/main/java/com/picday/diary/data/diary/database/PicDayDatabase.kt
+++ b/app/src/main/java/com/picday/diary/data/diary/database/PicDayDatabase.kt
@@ -4,12 +4,12 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import com.picday.diary.data.expense.dao.ExpenseDao
+import com.picday.diary.data.expense.entity.ExpenseEntity
 import com.picday.diary.data.diary.dao.DiaryDao
 import com.picday.diary.data.diary.dao.DiaryPhotoDao
-import com.picday.diary.data.diary.dao.ExpenseDao
 import com.picday.diary.data.diary.entity.DiaryEntity
 import com.picday.diary.data.diary.entity.DiaryPhotoEntity
-import com.picday.diary.data.diary.entity.ExpenseEntity
 
 @Database(
     entities = [DiaryEntity::class, DiaryPhotoEntity::class, ExpenseEntity::class],

--- a/app/src/main/java/com/picday/diary/data/expense/dao/ExpenseDao.kt
+++ b/app/src/main/java/com/picday/diary/data/expense/dao/ExpenseDao.kt
@@ -1,11 +1,11 @@
-package com.picday.diary.data.diary.dao
+package com.picday.diary.data.expense.dao
 
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
-import com.picday.diary.data.diary.entity.ExpenseEntity
+import com.picday.diary.data.expense.entity.ExpenseEntity
 import kotlinx.coroutines.flow.Flow
 
 @Dao

--- a/app/src/main/java/com/picday/diary/data/expense/entity/ExpenseEntity.kt
+++ b/app/src/main/java/com/picday/diary/data/expense/entity/ExpenseEntity.kt
@@ -1,9 +1,10 @@
-﻿package com.picday.diary.data.diary.entity
+package com.picday.diary.data.expense.entity
 
 import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
+import com.picday.diary.data.diary.entity.DiaryEntity
 import com.picday.diary.domain.expense.Expense
 
 @Entity(
@@ -20,7 +21,7 @@ import com.picday.diary.domain.expense.Expense
 )
 data class ExpenseEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0L,
-    // 기존 DiaryEntity.id가 String 타입이므로 FK 타입을 동일하게 맞춘다.
+    // DiaryEntity.id가 String 타입이라 FK도 String으로 맞춘다.
     val diaryId: String,
     val title: String,
     val amount: Int,

--- a/app/src/main/java/com/picday/diary/data/expense/repository/ExpenseRepositoryImpl.kt
+++ b/app/src/main/java/com/picday/diary/data/expense/repository/ExpenseRepositoryImpl.kt
@@ -1,14 +1,15 @@
-package com.picday.diary.data.diary.repository
+package com.picday.diary.data.expense.repository
 
-import com.picday.diary.data.diary.dao.ExpenseDao
-import com.picday.diary.data.diary.entity.toDomain
-import com.picday.diary.data.diary.entity.toEntity
+import com.picday.diary.data.expense.dao.ExpenseDao
+import com.picday.diary.data.expense.entity.toDomain
+import com.picday.diary.data.expense.entity.toEntity
 import com.picday.diary.domain.expense.Expense
-import com.picday.diary.domain.repository.ExpenseRepository
+import com.picday.diary.domain.expense.ExpenseRepository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import javax.inject.Inject
 
-class RoomExpenseRepository(
+class ExpenseRepositoryImpl @Inject constructor(
     private val expenseDao: ExpenseDao
 ) : ExpenseRepository {
     override suspend fun addExpense(expense: Expense) {

--- a/app/src/main/java/com/picday/diary/di/DiaryModule.kt
+++ b/app/src/main/java/com/picday/diary/di/DiaryModule.kt
@@ -2,14 +2,14 @@ package com.picday.diary.di
 
 import android.content.Context
 import androidx.room.Room
+import com.picday.diary.data.expense.dao.ExpenseDao
+import com.picday.diary.data.expense.repository.ExpenseRepositoryImpl
 import com.picday.diary.data.diary.dao.DiaryDao
 import com.picday.diary.data.diary.dao.DiaryPhotoDao
-import com.picday.diary.data.diary.dao.ExpenseDao
 import com.picday.diary.data.diary.database.PicDayDatabase
-import com.picday.diary.data.diary.repository.RoomExpenseRepository
 import com.picday.diary.data.diary.repository.RoomDiaryRepository
+import com.picday.diary.domain.expense.ExpenseRepository
 import com.picday.diary.domain.repository.DiaryRepository
-import com.picday.diary.domain.repository.ExpenseRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -52,7 +52,7 @@ object DiaryModule {
     fun provideExpenseRepository(
         expenseDao: ExpenseDao
     ): ExpenseRepository {
-        return RoomExpenseRepository(expenseDao)
+        return ExpenseRepositoryImpl(expenseDao)
     }
 
     @Provides

--- a/app/src/main/java/com/picday/diary/domain/expense/ExpenseRepository.kt
+++ b/app/src/main/java/com/picday/diary/domain/expense/ExpenseRepository.kt
@@ -1,6 +1,5 @@
-package com.picday.diary.domain.repository
+package com.picday.diary.domain.expense
 
-import com.picday.diary.domain.expense.Expense
 import kotlinx.coroutines.flow.Flow
 
 interface ExpenseRepository {

--- a/app/src/main/java/com/picday/diary/domain/usecase/expense/AddExpenseUseCase.kt
+++ b/app/src/main/java/com/picday/diary/domain/usecase/expense/AddExpenseUseCase.kt
@@ -1,7 +1,7 @@
 package com.picday.diary.domain.usecase.expense
 
 import com.picday.diary.domain.expense.Expense
-import com.picday.diary.domain.repository.ExpenseRepository
+import com.picday.diary.domain.expense.ExpenseRepository
 import javax.inject.Inject
 
 class AddExpenseUseCase @Inject constructor(

--- a/app/src/main/java/com/picday/diary/domain/usecase/expense/DeleteExpenseUseCase.kt
+++ b/app/src/main/java/com/picday/diary/domain/usecase/expense/DeleteExpenseUseCase.kt
@@ -1,7 +1,7 @@
 package com.picday.diary.domain.usecase.expense
 
 import com.picday.diary.domain.expense.Expense
-import com.picday.diary.domain.repository.ExpenseRepository
+import com.picday.diary.domain.expense.ExpenseRepository
 import javax.inject.Inject
 
 class DeleteExpenseUseCase @Inject constructor(

--- a/app/src/main/java/com/picday/diary/domain/usecase/expense/GetDiaryExpenseTotalUseCase.kt
+++ b/app/src/main/java/com/picday/diary/domain/usecase/expense/GetDiaryExpenseTotalUseCase.kt
@@ -1,6 +1,6 @@
 package com.picday.diary.domain.usecase.expense
 
-import com.picday.diary.domain.repository.ExpenseRepository
+import com.picday.diary.domain.expense.ExpenseRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 

--- a/app/src/main/java/com/picday/diary/domain/usecase/expense/GetDiaryExpensesUseCase.kt
+++ b/app/src/main/java/com/picday/diary/domain/usecase/expense/GetDiaryExpensesUseCase.kt
@@ -1,7 +1,7 @@
 package com.picday.diary.domain.usecase.expense
 
 import com.picday.diary.domain.expense.Expense
-import com.picday.diary.domain.repository.ExpenseRepository
+import com.picday.diary.domain.expense.ExpenseRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 


### PR DESCRIPTION
 ## 변경 목적
  Expense 도메인 계약을 Room 데이터 계층과 연결하기 위해 `ExpenseRepositoryImpl`을 추가했습니다.

  ## 주요 변경 사항
  - 도메인
    - `Expense` 모델 추가
    - `ExpenseRepository` 인터페이스 추가
  - 데이터
    - `ExpenseEntity` 추가
    - `ExpenseEntity <-> Expense` 매퍼 추가
    - `ExpenseDao` 추가
      - insert/delete
      - diaryId 기준 목록 조회(Flow)
      - diaryId 기준 총합 조회(Flow<Long>)
    - `ExpenseRepositoryImpl` 추가 (Room + Flow 매핑)

  ## 설계 포인트
  - Clean Architecture 원칙 유지
  - Repository Pattern 적용
  - 조회는 Flow로 노출해 프레젠테이션 계층 반응형 처리 지원
  - 총액 타입은 오버플로우 리스크를 고려해 Long 사용

Closes #72 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal code structure to improve maintainability and logical grouping of expense-related functionality. No changes to user-facing features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->