### PR TITLE
feat: 지출 내역 관리를 위한 MVI 기반 ExpenseViewModel 및 관련 클래스 추가

### DIFF
--- a/app/src/main/java/com/picday/diary/presentation/expense/ExpenseIntent.kt
+++ b/app/src/main/java/com/picday/diary/presentation/expense/ExpenseIntent.kt
@@ -1,0 +1,9 @@
+package com.picday.diary.presentation.expense
+
+import com.picday.diary.domain.expense.Expense
+
+sealed interface ExpenseIntent {
+    data class LoadExpenses(val diaryId: String) : ExpenseIntent
+    data class AddExpense(val expense: Expense) : ExpenseIntent
+    data class DeleteExpense(val expense: Expense) : ExpenseIntent
+}

--- a/app/src/main/java/com/picday/diary/presentation/expense/ExpenseState.kt
+++ b/app/src/main/java/com/picday/diary/presentation/expense/ExpenseState.kt
@@ -1,0 +1,9 @@
+package com.picday.diary.presentation.expense
+
+import com.picday.diary.domain.expense.Expense
+
+data class ExpenseState(
+    val expenses: List<Expense> = emptyList(),
+    val totalExpense: Int = 0,
+    val loading: Boolean = false
+)

--- a/app/src/main/java/com/picday/diary/presentation/expense/ExpenseState.kt
+++ b/app/src/main/java/com/picday/diary/presentation/expense/ExpenseState.kt
@@ -5,5 +5,6 @@ import com.picday.diary.domain.expense.Expense
 data class ExpenseState(
     val expenses: List<Expense> = emptyList(),
     val totalExpense: Int = 0,
-    val loading: Boolean = false
+    val loading: Boolean = false,
+    val errorMessage: String? = null
 )

--- a/app/src/main/java/com/picday/diary/presentation/expense/ExpenseViewModel.kt
+++ b/app/src/main/java/com/picday/diary/presentation/expense/ExpenseViewModel.kt
@@ -1,0 +1,93 @@
+package com.picday.diary.presentation.expense
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.picday.diary.domain.usecase.expense.AddExpenseUseCase
+import com.picday.diary.domain.usecase.expense.DeleteExpenseUseCase
+import com.picday.diary.domain.usecase.expense.GetDiaryExpenseTotalUseCase
+import com.picday.diary.domain.usecase.expense.GetDiaryExpensesUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class ExpenseViewModel @Inject constructor(
+    private val addExpenseUseCase: AddExpenseUseCase,
+    private val deleteExpenseUseCase: DeleteExpenseUseCase,
+    private val getDiaryExpensesUseCase: GetDiaryExpensesUseCase,
+    private val getDiaryExpenseTotalUseCase: GetDiaryExpenseTotalUseCase
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(ExpenseState())
+    val state: StateFlow<ExpenseState> = _state.asStateFlow()
+
+    private var observeJob: Job? = null
+    private var currentDiaryId: String? = null
+
+    // 화면에서 들어오는 Intent를 단일 진입점으로 처리한다.
+    fun processIntent(intent: ExpenseIntent) {
+        when (intent) {
+            is ExpenseIntent.LoadExpenses -> handleLoadExpenses(intent.diaryId)
+            is ExpenseIntent.AddExpense -> handleAddExpense(intent)
+            is ExpenseIntent.DeleteExpense -> handleDeleteExpense(intent)
+        }
+    }
+
+    private fun handleLoadExpenses(diaryId: String) {
+        currentDiaryId = diaryId
+        observeJob?.cancel()
+        _state.update { it.copy(loading = true) }
+
+        observeJob = viewModelScope.launch {
+            // 목록/총액 Flow를 결합해 하나의 상태로 동기화한다.
+            combine(
+                getDiaryExpensesUseCase(diaryId),
+                getDiaryExpenseTotalUseCase(diaryId)
+            ) { expenses, total ->
+                expenses to total
+            }
+                .catch {
+                    _state.update { current -> current.copy(loading = false) }
+                }
+                .collect { (expenses, total) ->
+                    _state.update { current ->
+                        current.copy(
+                            expenses = expenses,
+                            totalExpense = total.toSafeInt(),
+                            loading = false
+                        )
+                    }
+                }
+        }
+    }
+
+    private fun handleAddExpense(intent: ExpenseIntent.AddExpense) {
+        viewModelScope.launch {
+            addExpenseUseCase(intent.expense)
+            // 목록은 LoadExpenses에서 구독한 Flow가 자동 갱신한다.
+        }
+    }
+
+    private fun handleDeleteExpense(intent: ExpenseIntent.DeleteExpense) {
+        viewModelScope.launch {
+            deleteExpenseUseCase(intent.expense)
+            // 목록은 LoadExpenses에서 구독한 Flow가 자동 갱신한다.
+        }
+    }
+
+    // Long 총액을 Int 상태로 안전하게 변환한다.
+    private fun Long.toSafeInt(): Int {
+        return when {
+            this > Int.MAX_VALUE.toLong() -> Int.MAX_VALUE
+            this < Int.MIN_VALUE.toLong() -> Int.MIN_VALUE
+            else -> this.toInt()
+        }
+    }
+}

--- a/app/src/main/java/com/picday/diary/presentation/expense/ExpenseViewModel.kt
+++ b/app/src/main/java/com/picday/diary/presentation/expense/ExpenseViewModel.kt
@@ -7,6 +7,7 @@ import com.picday.diary.domain.usecase.expense.DeleteExpenseUseCase
 import com.picday.diary.domain.usecase.expense.GetDiaryExpenseTotalUseCase
 import com.picday.diary.domain.usecase.expense.GetDiaryExpensesUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.util.concurrent.CancellationException
 import javax.inject.Inject
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -43,7 +44,7 @@ class ExpenseViewModel @Inject constructor(
     private fun handleLoadExpenses(diaryId: String) {
         currentDiaryId = diaryId
         observeJob?.cancel()
-        _state.update { it.copy(loading = true) }
+        _state.update { it.copy(loading = true, errorMessage = null) }
 
         observeJob = viewModelScope.launch {
             // 목록/총액 Flow를 결합해 하나의 상태로 동기화한다.
@@ -53,15 +54,22 @@ class ExpenseViewModel @Inject constructor(
             ) { expenses, total ->
                 expenses to total
             }
-                .catch {
-                    _state.update { current -> current.copy(loading = false) }
+                .catch { throwable ->
+                    if (throwable is CancellationException) throw throwable
+                    _state.update { current ->
+                        current.copy(
+                            loading = false,
+                            errorMessage = throwable.message ?: "지출 내역을 불러오지 못했습니다."
+                        )
+                    }
                 }
                 .collect { (expenses, total) ->
                     _state.update { current ->
                         current.copy(
                             expenses = expenses,
                             totalExpense = total.toSafeInt(),
-                            loading = false
+                            loading = false,
+                            errorMessage = null
                         )
                     }
                 }
@@ -70,15 +78,31 @@ class ExpenseViewModel @Inject constructor(
 
     private fun handleAddExpense(intent: ExpenseIntent.AddExpense) {
         viewModelScope.launch {
-            addExpenseUseCase(intent.expense)
-            // 목록은 LoadExpenses에서 구독한 Flow가 자동 갱신한다.
+            try {
+                addExpenseUseCase(intent.expense)
+                // 목록은 LoadExpenses에서 구독한 Flow가 자동 갱신한다.
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _state.update { current ->
+                    current.copy(errorMessage = e.message ?: "지출 추가에 실패했습니다.")
+                }
+            }
         }
     }
 
     private fun handleDeleteExpense(intent: ExpenseIntent.DeleteExpense) {
         viewModelScope.launch {
-            deleteExpenseUseCase(intent.expense)
-            // 목록은 LoadExpenses에서 구독한 Flow가 자동 갱신한다.
+            try {
+                deleteExpenseUseCase(intent.expense)
+                // 목록은 LoadExpenses에서 구독한 Flow가 자동 갱신한다.
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                _state.update { current ->
+                    current.copy(errorMessage = e.message ?: "지출 삭제에 실패했습니다.")
+                }
+            }
         }
     }
 


### PR DESCRIPTION
 ## 변경 목적
  Expense 기능의 화면 상태 관리를 MVVM + MVI 형태로 구성하기 위해
  State/Intent/ViewModel을 신규 추가했습니다.

  ## 주요 변경 사항
  - `presentation/expense/ExpenseState.kt` 추가
  - `presentation/expense/ExpenseIntent.kt` 추가
  - `presentation/expense/ExpenseViewModel.kt` 추가

  ## 구현 포인트
  - ViewModel은 `StateFlow`로 단일 UI 상태를 노출
  - `processIntent`로 Intent를 일관 처리
  - `LoadExpenses`는 `GetDiaryExpensesUseCase` + `GetDiaryExpenseTotalUseCase`를 `combine`해 동기화
  - `AddExpense`/`DeleteExpense`는 각각 UseCase 호출
  - 총액은 도메인 `Long` 값을 상태 `Int` 요구사항에 맞춰 안전 변환 처리

Closes #74 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage expenses per diary: load, add, and delete expense entries from the UI.
  * Automatic calculation and display of total expenses for each diary.
  * Improved loading and error handling with real-time updates when switching diaries, ensuring UI stays in sync during operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->